### PR TITLE
Add format for fields of type integer

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -404,10 +404,22 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				}
 			}
 			schema.Properties[fieldName] = ref
-			if strings.Contains(gormTagValue, "default") {
-				defaultValue := getDefaultValue(gormTagValue)
-				schema.Properties[fieldName].Value.Default = defaultValue
+
+			// Add default value to the attributes.
+			if strings.Contains(gormTagValue, "default:") {
+				schema.Properties[fieldName].Value.Default = getDefaultValue(gormTagValue)
 			}
+
+			// Add format to the attributes.
+			if f.Type.Kind() == reflect.Int64 {
+				schema.Properties[fieldName].Value.Format = "int64"
+			} else if f.Type.Kind() == reflect.Uint || f.Type.Kind() == reflect.Uint8 || f.Type.Kind() == reflect.Uint16 ||
+				f.Type.Kind() == reflect.Uint32 || f.Type.Kind() == reflect.Uint64 {
+				schema.Properties[fieldName].Value.Format = "int64"
+				minValue := 0.0
+				schema.Properties[fieldName].Value.Min = &minValue
+			}
+
 			isPtr := f.Type.Kind() == reflect.Pointer
 			hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
 			if isFieldRequired(isPtr, hasOmitEmptySet) {


### PR DESCRIPTION
## STATUS
Ready

## DESCRIPTION
Add format to the attributes.
OpenAPI 3.0 supports only two formats: `int64` and `int32`.
For fields of type `int64`, the format is specified as `int64`.
For all unsigned types, the format is specified as `int64`, along with adding the `minimum` attribute set to zero (similar to NVO).
For fields of type `int8`, `int16`, and `int32`, the format is not specified. By default, for these types, `int32` will be the type in Swagger models.

### Requirement for the above changes:
Since no format was specified in `openapi.yaml`, all integer fields were generated as `int32` in Swagger models. To handle this, the format needs to be specified in `openapi.yaml`.