### PR TITLE
Add support for formats on slices of int64 and uint types

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -490,7 +490,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 	return
 }
 
-// Function to return schema without Min value
+// createIntegerSchema returns schema without Min value
 func createIntegerSchema() *openapi3.Schema {
 	return &openapi3.Schema{
 		Type:   &openapi3.Types{"integer"},
@@ -498,7 +498,7 @@ func createIntegerSchema() *openapi3.Schema {
 	}
 }
 
-// Function to return schema with Min value set to 0.0
+// createIntegerSchemaWithMin returns schema with Min value set to 0.0
 func createIntegerSchemaWithMin() *openapi3.Schema {
 	minValue := 0.0
 	return &openapi3.Schema{
@@ -508,22 +508,22 @@ func createIntegerSchemaWithMin() *openapi3.Schema {
 	}
 }
 
-// Function to return the array schema with items created using createIntegerSchema()
+// createArraySchemaWithIntegerItems returns the array schema with items created using createIntegerSchema()
 func createArraySchemaWithIntegerItems() *openapi3.Schema {
 	return &openapi3.Schema{
 		Type: &openapi3.Types{"array"},
 		Items: &openapi3.SchemaRef{
-			Value: createIntegerSchema(), // Use createIntegerSchema for items
+			Value: createIntegerSchema(),
 		},
 	}
 }
 
-// Function to return the array schema with items created using createIntegerSchemaWithMin
+// createArraySchemaWithIntegerItemsWithMin returns the array schema with items created using createIntegerSchemaWithMin
 func createArraySchemaWithIntegerItemsWithMin() *openapi3.Schema {
 	return &openapi3.Schema{
 		Type: &openapi3.Types{"array"},
 		Items: &openapi3.SchemaRef{
-			Value: createIntegerSchemaWithMin(), // Use createIntegerSchemaWithMin for items
+			Value: createIntegerSchemaWithMin(),
 		},
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -418,9 +418,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				schema.Properties[fieldName].Value.Format = "int64"
 				minValue := 0.0
 				schema.Properties[fieldName].Value.Min = &minValue
-			}
-
-			if f.Type.Kind() == reflect.Slice {
+			} else if f.Type.Kind() == reflect.Slice {
 				elementType := f.Type.Elem().Kind()
 				if elementType == reflect.Int64 {
 					schema.Properties[fieldName] = &openapi3.SchemaRef{

--- a/schema.go
+++ b/schema.go
@@ -424,12 +424,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				elementType := f.Type.Elem().Kind()
 				if elementType == reflect.Int64 {
 					schema.Properties[fieldName] = &openapi3.SchemaRef{
-						Value: &openapi3.Schema{
-							Type: &openapi3.Types{"array"},
-							Items: &openapi3.SchemaRef{
-								Value: createIntegerSchema(),
-							},
-						},
+						Value: createArraySchemaWithIntegerItems(),
 					}
 				} else if elementType == reflect.Uint || elementType == reflect.Uint8 || elementType == reflect.Uint16 || elementType == reflect.Uint32 || elementType == reflect.Uint64 {
 					schema.Properties[fieldName] = &openapi3.SchemaRef{
@@ -447,12 +442,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 							Value: &openapi3.Schema{
 								Type: &openapi3.Types{"array"},
 								Items: &openapi3.SchemaRef{
-									Value: &openapi3.Schema{
-										Type: &openapi3.Types{"array"},
-										Items: &openapi3.SchemaRef{
-											Value: createIntegerSchema(),
-										},
-									},
+									Value: createArraySchemaWithIntegerItems(),
 								},
 							},
 						}
@@ -562,6 +552,16 @@ func createIntegerSchemaWithMin() *openapi3.Schema {
 		Type:   &openapi3.Types{"integer"},
 		Format: "int64",
 		Min:    &minValue,
+	}
+}
+
+// Function to return the array schema with items created using createIntegerSchema()
+func createArraySchemaWithIntegerItems() *openapi3.Schema {
+	return &openapi3.Schema{
+		Type: &openapi3.Types{"array"},
+		Items: &openapi3.SchemaRef{
+			Value: createIntegerSchema(), // Use createIntegerSchema for items
+		},
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -454,43 +454,6 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 				}
 			}
 
-			// if f.Type.Kind() == reflect.Slice {
-			// elementType := f.Type.Elem().Kind()
-
-			// if elementType == reflect.Slice {
-			// 	innerElementType := f.Type.Elem().Elem().Kind()
-			// 	if innerElementType == reflect.Int64 {
-			// 		schema.Properties[fieldName] = &openapi3.SchemaRef{
-			// 			Value: &openapi3.Schema{
-			// 				Type: &openapi3.Types{"array"},
-			// 				Items: &openapi3.SchemaRef{
-			// 					Value: &openapi3.Schema{
-			// 						Type: &openapi3.Types{"array"},
-			// 						Items: &openapi3.SchemaRef{
-			// 							Value: createIntegerSchema(),
-			// 						},
-			// 					},
-			// 				},
-			// 			},
-			// 		}
-			// 	} else if innerElementType == reflect.Uint || innerElementType == reflect.Uint8 || innerElementType == reflect.Uint16 || innerElementType == reflect.Uint32 || innerElementType == reflect.Uint64 {
-			// 		schema.Properties[fieldName] = &openapi3.SchemaRef{
-			// 			Value: &openapi3.Schema{
-			// 				Type: &openapi3.Types{"array"},
-			// 				Items: &openapi3.SchemaRef{
-			// 					Value: &openapi3.Schema{
-			// 						Type: &openapi3.Types{"array"},
-			// 						Items: &openapi3.SchemaRef{
-			// 							Value: createIntegerSchemaWithMin(),
-			// 						},
-			// 					},
-			// 				},
-			// 			},
-			// 		}
-			// 	}
-			// }
-			// }
-
 			isPtr := f.Type.Kind() == reflect.Pointer
 			hasOmitEmptySet := slices.Contains(jsonTags, "omitempty")
 			if isFieldRequired(isPtr, hasOmitEmptySet) {

--- a/schema.go
+++ b/schema.go
@@ -428,12 +428,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 					}
 				} else if elementType == reflect.Uint || elementType == reflect.Uint8 || elementType == reflect.Uint16 || elementType == reflect.Uint32 || elementType == reflect.Uint64 {
 					schema.Properties[fieldName] = &openapi3.SchemaRef{
-						Value: &openapi3.Schema{
-							Type: &openapi3.Types{"array"},
-							Items: &openapi3.SchemaRef{
-								Value: createIntegerSchemaWithMin(),
-							},
-						},
+						Value: createArraySchemaWithIntegerItemsWithMin(),
 					}
 				} else if elementType == reflect.Slice {
 					innerElementType := f.Type.Elem().Elem().Kind()
@@ -451,12 +446,7 @@ func (api *API) RegisterModel(model Model, opts ...ModelOpts) (name string, sche
 							Value: &openapi3.Schema{
 								Type: &openapi3.Types{"array"},
 								Items: &openapi3.SchemaRef{
-									Value: &openapi3.Schema{
-										Type: &openapi3.Types{"array"},
-										Items: &openapi3.SchemaRef{
-											Value: createIntegerSchemaWithMin(),
-										},
-									},
+									Value: createArraySchemaWithIntegerItemsWithMin(),
 								},
 							},
 						}
@@ -561,6 +551,16 @@ func createArraySchemaWithIntegerItems() *openapi3.Schema {
 		Type: &openapi3.Types{"array"},
 		Items: &openapi3.SchemaRef{
 			Value: createIntegerSchema(), // Use createIntegerSchema for items
+		},
+	}
+}
+
+// Function to return the array schema with items created using createIntegerSchemaWithMin
+func createArraySchemaWithIntegerItemsWithMin() *openapi3.Schema {
+	return &openapi3.Schema{
+		Type: &openapi3.Types{"array"},
+		Items: &openapi3.SchemaRef{
+			Value: createIntegerSchemaWithMin(), // Use createIntegerSchemaWithMin for items
 		},
 	}
 }


### PR DESCRIPTION
# Status
READY

# Description
Add formats to fields of type []int8, []int16, []int32, []int64, [][]int8, [][]int16, [][]int32, [][]int64, []uint8, []uint16, []uint32, []uint64, [][]uint8, [][]uint16, [][]uint32, [][]uint64.


OpenAPI 3.0 supports only two formats: `int64` and `int32`.
For fields of type `int64`, the format is specified as `int64`.
For all unsigned types, the format is specified as `int64`, along with adding the `minimum` attribute set to zero (similar to NVO).
For fields of type `int8`, `int16`, and `int32`, the format is not specified. By default, for these types, `int32` will be the type in Swagger models.

### Requirement for the above changes:
Since no format was specified in `openapi.yaml`, all integer fields were generated as `int32` in Swagger models. To handle this, the format needs to be specified in `openapi.yaml`.

![101](https://github.com/user-attachments/assets/45545a25-fc83-481f-a18e-406145e0bbc2)
![102](https://github.com/user-attachments/assets/28bf92fb-7863-4ceb-9216-84e6c0062445)


