### PR TITLE
Correcting Default Value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/google/go-cmp v0.5.9
+	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
 	golang.org/x/tools v0.20.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -21,5 +22,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
@@ -30,6 +31,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
@@ -40,6 +45,9 @@ golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.20.0 h1:hz/CVckiOxybQvFw6h7b/q80NTr9IUQb4s1IIzW7KNY=
 golang.org/x/tools v0.20.0/go.mod h1:WvitBU7JJf6A4jOdg4S1tviW9bhUxkgeCui/0JHctQg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -47,5 +55,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/schema.go
+++ b/schema.go
@@ -528,7 +528,15 @@ func createArraySchemaWithIntegerItemsWithMin() *openapi3.Schema {
 
 func getDefaultValue(gormTagValue string) interface{} {
 	defaultIndex := strings.Index(gormTagValue, "default:")
+	if defaultIndex == -1 {
+		fmt.Println("default value not found in gorm tag ", gormTagValue)
+		return nil
+	}
 	semicolonIndex := strings.Index(gormTagValue[defaultIndex:], ";")
+	if semicolonIndex == -1 {
+		fmt.Println("semicolon not found in gorm tag ", gormTagValue)
+		return nil
+	}
 	defaultValue := gormTagValue[defaultIndex+len("default:") : defaultIndex+semicolonIndex]
 
 	switch {

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"slices"
 	"sort"
@@ -528,14 +529,9 @@ func createArraySchemaWithIntegerItemsWithMin() *openapi3.Schema {
 
 func getDefaultValue(gormTagValue string) interface{} {
 	defaultIndex := strings.Index(gormTagValue, "default:")
-	if defaultIndex == -1 {
-		fmt.Println("default value not found in gorm tag ", gormTagValue)
-		return nil
-	}
 	semicolonIndex := strings.Index(gormTagValue[defaultIndex:], ";")
 	if semicolonIndex == -1 {
-		fmt.Println("semicolon not found in gorm tag ", gormTagValue)
-		return nil
+		log.Fatalln("semicolon not found in gorm tag ", gormTagValue)
 	}
 	defaultValue := gormTagValue[defaultIndex+len("default:") : defaultIndex+semicolonIndex]
 

--- a/schema.go
+++ b/schema.go
@@ -527,9 +527,9 @@ func createArraySchemaWithIntegerItemsWithMin() *openapi3.Schema {
 }
 
 func getDefaultValue(gormTagValue string) interface{} {
-	defaultIndex := strings.Index(gormTagValue, "default")
+	defaultIndex := strings.Index(gormTagValue, "default:")
 	semicolonIndex := strings.Index(gormTagValue[defaultIndex:], ";")
-	defaultValue := gormTagValue[defaultIndex+len("default:") : semicolonIndex]
+	defaultValue := gormTagValue[defaultIndex+len("default:") : defaultIndex+semicolonIndex]
 
 	switch {
 	case defaultValue == "true" || defaultValue == "false":

--- a/schema.go
+++ b/schema.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"slices"
 	"sort"
@@ -10,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/sirupsen/logrus"
 	"github.com/svatantra/rest/enums"
 	"github.com/svatantra/rest/getcomments/parser"
 	"golang.org/x/exp/constraints"
@@ -531,7 +531,7 @@ func getDefaultValue(gormTagValue string) interface{} {
 	defaultIndex := strings.Index(gormTagValue, "default:")
 	semicolonIndex := strings.Index(gormTagValue[defaultIndex:], ";")
 	if semicolonIndex == -1 {
-		log.Fatalln("semicolon not found in gorm tag ", gormTagValue)
+		logrus.Fatalln("semicolon not found in gorm tag ", gormTagValue)
 	}
 	defaultValue := gormTagValue[defaultIndex+len("default:") : defaultIndex+semicolonIndex]
 


### PR DESCRIPTION
## Status
**READY**

## Description
Correcting Default Value (Indexing of the gormtag value)
Throws Panic error when gorm contains multiple constraints including default tag not in the beginning.
Ex: gorm:"not null; default:3;"
`panic: runtime error: slice bounds out of range`

## Requirement
![image](https://github.com/user-attachments/assets/2c974737-f8ec-4992-8d27-2da0e8432369)
![image](https://github.com/user-attachments/assets/6cb5ae4d-271a-4cf1-a5ff-cbb3771557f4)

This change is required to accomodate multiple gorm tag contraints with the default constraint
In above example : field backbone_enabled has both default and not null constraint.
